### PR TITLE
installer: Fix typo preventing driver start on installation

### DIFF
--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -107,7 +107,7 @@ Name: AppStartMenu; Description: "Create Start Menu shortcuts"; Components: Appl
 Name: envPath; Description: "Add to PATH variable"; 
 
 [Run]
-Filename: "sc.exe"; Parameters: "start IRPMonDrv"; Description: "Start IRPMon driver"; Flags: postinstall shellexec unchecked;
+Filename: "sc.exe"; Parameters: "start IRPMnDrv"; Description: "Start IRPMon driver"; Flags: postinstall shellexec unchecked;
 Filename: "sc.exe"; Parameters: "start IRPMonSvc"; Description: "Start tIRPMon server service"; Flags: postinstall shellexec unchecked;
 Filename: "{app}\README.md"; Description: "View documentation"; Flags: skipifsilent postinstall shellexec unchecked;
 


### PR DESCRIPTION
If the user selects "Start Driver" in the installation wizard, I think the installer will try to launch "sc start IRPMonDrv" and nothing will start because the correct driver service name is "IRPMnDrv" without the "o".

This is untested, but it might explain parts of the trouble I have experienced.