### PR TITLE
gui: Correct driver path to allow start of driver

### DIFF
--- a/gui/IRPMon.dpr
+++ b/gui/IRPMon.dpr
@@ -135,7 +135,7 @@ Begin
         hScm := OpenSCManagerW(Nil, Nil, scmAccess);
 
       taskList := TTaskOperationList.Create;
-      serviceTask := TDriverTaskObject.Create(initInfo, hScm, serviceName, serviceDescription, serviceDescription, 'system32\drivers\\IRPMon\irpmndrv.sys');
+      serviceTask := TDriverTaskObject.Create(initInfo, hScm, serviceName, serviceDescription, serviceDescription, 'system32\drivers\IRPMon\irpmndrv.sys');
       serviceTask.SetCompletionCallback(OnServiceTaskComplete, Nil);
       If (connType = ictDevice) And (hScm <> 0) Then
         begin


### PR DESCRIPTION
If the driver has been uninstalled (e.g. by "sc delete IRPMnDrv"), the application will automatically install it on start-up. However it then introduces a double backslash that causes subsequent start-up attempts by "sc start IRPMnDrv" to fail.

This is untested, so I am not 100% sure I hit the right code spot with my patch, but I have seen in RegEdit that the double backslash is there after the application has started (and monitoring doesn't work). "sc start IRPMnDrv" will fail. If I manually edit the registry to remove the extra backslash, "sc start IRPMnDrv" will succeed, and monitoring will work afterwards.